### PR TITLE
chore: CI smoke test — compile-only PR build

### DIFF
--- a/BusinessCentral.Sentinel/src/Setup/TelemetryLogging.Enum.al
+++ b/BusinessCentral.Sentinel/src/Setup/TelemetryLogging.Enum.al
@@ -4,6 +4,7 @@ enum 71180279 TelemetryLogging
 {
     Access = Internal;
     Extensible = true;
+    // Controls how often Sentinel emits telemetry events.
 
     value(0; " ")
     {


### PR DESCRIPTION
Trivial one-line comment added to `TelemetryLogging.Enum.al` to trigger the new CI configuration:

- **AL-Go PR build** should run compile-only (no Docker container, no test execution) via `PullRequestHandler.settings.json`
- **AL Runner Tests** should run the unit test suite in parallel

Nothing functional changes here — this PR exists purely to verify the fast PR pipeline works.